### PR TITLE
grafana failed to get metrics from prometheus on ocp 4.4

### DIFF
--- a/pkg/controller/prometheusext/model/alertmanager.go
+++ b/pkg/controller/prometheusext/model/alertmanager.go
@@ -46,6 +46,13 @@ func alertmanagerLabels(cr *promext.PrometheusExt) map[string]string {
 	return labels
 }
 
+func alertmanagerSvcSelectors(cr *promext.PrometheusExt) map[string]string {
+	selectors := make(map[string]string)
+	selectors[App] = string(Alertmanager)
+	selectors[string(Alertmanager)] = AlertmanagerName(cr)
+	return selectors
+}
+
 //AlertmanagerConfigSecret create secret object to config alertmanager
 func AlertmanagerConfigSecret(cr *promext.PrometheusExt) *v1.Secret {
 	secret := &v1.Secret{
@@ -215,7 +222,7 @@ func NewAlertmanagetSvc(cr *promext.PrometheusExt) *v1.Service {
 					Port: cr.Spec.AlertManagerConfig.ServicePort,
 				},
 			},
-			Selector: alertmanagerLabels(cr),
+			Selector: alertmanagerSvcSelectors(cr),
 			Type:     v1.ServiceTypeClusterIP,
 		},
 	}
@@ -226,7 +233,7 @@ func NewAlertmanagetSvc(cr *promext.PrometheusExt) *v1.Service {
 func UpdatedAlertmanagetSvc(cr *promext.PrometheusExt, curr *v1.Service) *v1.Service {
 	svc := curr.DeepCopy()
 	svc.Labels = alertmanagerLabels(cr)
-	svc.Spec.Selector = alertmanagerLabels(cr)
+	svc.Spec.Selector = alertmanagerSvcSelectors(cr)
 	svc.Spec.Ports[0].Port = cr.Spec.AlertManagerConfig.ServicePort
 	return svc
 }

--- a/pkg/controller/prometheusext/model/constants.go
+++ b/pkg/controller/prometheusext/model/constants.go
@@ -17,6 +17,7 @@
 package model
 
 const (
+	App             = "app"
 	None            = "None"
 	StorageClassAnn = "storage-class-name"
 	Ready           = "Ready"

--- a/pkg/controller/prometheusext/model/prometheus.go
+++ b/pkg/controller/prometheusext/model/prometheus.go
@@ -89,7 +89,7 @@ func NewPrometheusSvc(cr *promext.PrometheusExt) *v1.Service {
 					Port: cr.Spec.PrometheusConfig.ServicePort,
 				},
 			},
-			Selector: PrometheusLabels(cr),
+			Selector: prometheusSvcSelectors(cr),
 			Type:     v1.ServiceTypeClusterIP,
 		},
 	}
@@ -101,7 +101,7 @@ func UpdatedPrometheusSvc(cr *promext.PrometheusExt, currentSvc *v1.Service) *v1
 	svc := currentSvc.DeepCopy()
 	svc.Labels = PrometheusLabels(cr)
 	svc.Spec.Ports[0].Port = cr.Spec.PrometheusConfig.ServicePort
-	svc.Spec.Selector = PrometheusLabels(cr)
+	svc.Spec.Selector = prometheusSvcSelectors(cr)
 	return svc
 }
 
@@ -181,6 +181,13 @@ func PrometheusLabels(cr *promext.PrometheusExt) map[string]string {
 		labels[key] = v
 	}
 	return labels
+}
+
+func prometheusSvcSelectors(cr *promext.PrometheusExt) map[string]string {
+	selectors := make(map[string]string)
+	selectors[App] = string(Prometheus)
+	selectors[string(Prometheus)] = PromethuesName(cr)
+	return selectors
 }
 
 func prometheusSpec(cr *promext.PrometheusExt) (*promv1.PrometheusSpec, error) {


### PR DESCRIPTION
Somehow podMetadata info in Prometheus CR is not set on OCP 4.4. And it leads to services of both prometheus and alertmanager fail to find endpoints by their selectors.
Before looking into Prometheus Operator, it makes sense to use only necessary labels as service selectors