### PR TITLE
Fix rbac wildchar issue for 36eus

### DIFF
--- a/deploy/olm-catalog/ibm-monitoring-prometheus-operator-ext/1.9.6/ibm-monitoring-prometheus-operator-ext.v1.9.6.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-monitoring-prometheus-operator-ext/1.9.6/ibm-monitoring-prometheus-operator-ext.v1.9.6.clusterserviceversion.yaml
@@ -220,7 +220,12 @@ spec:
                 - configmaps
                 - secrets
               verbs:
-                - "*"
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - delete
             - apiGroups:
                 - apps
               resources:
@@ -228,7 +233,12 @@ spec:
                 - statefulsets
                 - replicasets
               verbs:
-                - "*"
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - delete
             - apiGroups:
                 - monitoring.coreos.com
               resources:
@@ -237,13 +247,23 @@ spec:
                 - servicemonitors
                 - prometheusrules
               verbs:
-                - "*"
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - delete
             - apiGroups:
                 - certmanager.k8s.io
               resources:
                 - certificates
               verbs:
-                - "*"
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - delete
             - apiGroups:
                 - monitoring.operator.ibm.com
               resources:
@@ -251,19 +271,23 @@ spec:
                 - prometheusexts/finalizers
                 - prometheusexts/status
               verbs:
-                - "*"
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - delete
             - apiGroups:
                 - extensions
               resources:
                 - ingresses
               verbs:
-                - "*"
-            - apiGroups:
-                - certmanager.k8s.io
-              resources:
-                - issuers
-              verbs:
-                - use
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - delete
           serviceAccountName: ibm-monitoring-prometheus-operator-ext
         - rules:
             - apiGroups:
@@ -276,13 +300,23 @@ spec:
                 - pods
                 - services/finalizers
               verbs:
-                - "*"
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - delete
             - apiGroups:
                 - apiextensions.k8s.io
               resources:
                 - customresourcedefinitions
               verbs:
-                - "*"
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - delete
             - apiGroups:
                 - ""
               resources:
@@ -296,13 +330,23 @@ spec:
               resources:
                 - statefulsets
               verbs:
-                - "*"
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - delete
             - apiGroups:
                 - batch
               resources:
                 - jobs
               verbs:
-                - "*"
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - delete
             - apiGroups:
                 - monitoring.coreos.com
               resources:
@@ -314,13 +358,23 @@ spec:
                 - prometheuses/finalizers
                 - alertmanagers/finalizers
               verbs:
-                - "*"
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - delete
             - apiGroups:
                 - "monitoringcontroller.cloud.ibm.com"
               resources:
                 - monitoringdashboards
               verbs:
-                - "*"
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - delete
             - apiGroups:
                 - "mcm.ibm.com"
               resources:
@@ -336,7 +390,12 @@ spec:
               resources:
                 - customresourcedefinitions
               verbs:
-                - "*"
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - delete
             - apiGroups:
                 - monitoring.coreos.com
               resources:
@@ -345,20 +404,35 @@ spec:
                 - prometheuses/finalizers
                 - alertmanagers/finalizers
               verbs:
-                - "*"
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - delete
             - apiGroups:
                 - apps
               resources:
                 - statefulsets
               verbs:
-                - "*"
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - delete
             - apiGroups:
                 - ""
               resources:
                 - configmaps
                 - secrets
               verbs:
-                - "*"
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - delete
             - apiGroups:
                 - ""
               resources:
@@ -387,7 +461,12 @@ spec:
                 - podmonitors
                 - prometheusrules
               verbs:
-                - "*"
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - delete
             - apiGroups:
                 - ""
               resources:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -42,7 +42,12 @@ rules:
   - podmonitors
   - prometheusrules
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
 - apiGroups:
   - ''
   resources:
@@ -98,7 +103,12 @@ rules:
   - configmaps
   - secrets
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
 - apiGroups:
   - apps
   resources:
@@ -106,7 +116,12 @@ rules:
   - statefulsets
   - replicasets
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
 - apiGroups:
   - monitoring.coreos.com
   resources:
@@ -115,13 +130,23 @@ rules:
   - servicemonitors
   - prometheusrules
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
 - apiGroups:
   - certmanager.k8s.io
   resources:
   - certificates
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
 - apiGroups:
   - monitoring.operator.ibm.com
   resources:
@@ -129,19 +154,23 @@ rules:
   - prometheusexts/finalizers
   - prometheusexts/status
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
 - apiGroups:
   - extensions
   resources:
   - ingresses
   verbs:
-  - '*'
-- apiGroups:
-  - certmanager.k8s.io
-  resources:
-  - issuers
-  verbs:
-  - use
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -163,13 +192,23 @@ rules:
   - pods
   - services/finalizers
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
 - apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
 - apiGroups:
   - ""
   resources:
@@ -184,13 +223,23 @@ rules:
   resources:
   - statefulsets
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
 - apiGroups:
   - batch
   resources:
   - jobs
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
 - apiGroups:
   - monitoring.coreos.com
   resources:
@@ -202,13 +251,23 @@ rules:
   - prometheuses/finalizers
   - alertmanagers/finalizers
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
 - apiGroups:
   - "monitoringcontroller.cloud.ibm.com"
   resources:
   - monitoringdashboards
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
 - apiGroups:
   - "mcm.ibm.com"
   resources:
@@ -233,7 +292,12 @@ rules:
   resources:
   - customresourcedefinitions
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
 - apiGroups:
   - monitoring.coreos.com
   resources:
@@ -242,20 +306,35 @@ rules:
   - prometheuses/finalizers
   - alertmanagers/finalizers
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
 - apiGroups:
   - apps
   resources:
   - statefulsets
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
 - apiGroups:
   - ''
   resources:
   - configmaps
   - secrets
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
 - apiGroups:
   - ''
   resources:


### PR DESCRIPTION
In order to reduce the namespace-scope operator permissions, we need the operator and operands have enumerated the required verbs. Hence part of fix , we are removing the wildchar (*) verb and specified the required verbs in the CSV as well as in the role file.

Issue https://github.ibm.com/IBMPrivateCloud/roadmap/issues/45003