### PR TITLE
Fix rbac wildchar issue

### DIFF
--- a/deploy/olm-catalog/ibm-monitoring-prometheus-operator-ext/1.11.0/ibm-monitoring-prometheus-operator-ext.v1.11.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-monitoring-prometheus-operator-ext/1.11.0/ibm-monitoring-prometheus-operator-ext.v1.11.0.clusterserviceversion.yaml
@@ -1,0 +1,610 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  labels:
+    app.kubernetes.io/name: ibm-monitoring
+    app.kubernetes.io/instance: common-monitoring
+    app.kubernetes.io/managed-by: ibm-monitoring-prometheusext-operator
+    operatorframework.io/arch.s390x: supported
+    operatorframework.io/os.linux: supported
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.ppc64le: supported
+  annotations:
+    olm.skipRange: "<1.11.0"
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "monitoring.operator.ibm.com/v1alpha1",
+          "kind": "PrometheusExt",
+          "metadata": {
+            "name": "ibm-monitoring"
+          },
+          "spec": {
+            "alertManagerConfig": {
+              "logLevel": "info",
+              "serviceAccount": "ibm-monitoring-prometheusext-operand",
+              "servicePort": 9093
+            },
+            "certs": {
+              "autoClean": true,
+              "issuer": "cs-ca-clusterissuer",
+              "monitoringClientSecret": "ibm-monitoring-client-certs",
+              "monitoringSecret": "ibm-monitoring-certs"
+            },
+            "clusterPort": 443,
+            "grafanaSvcName": "ibm-monitoring-grafana",
+            "grafanaSvcPort": 3000,
+            "iamProvider": {
+              "idManagementSvc": "platform-identity-management",
+              "idManagementSvcPort": 4500,
+              "idProviderSvc": "platform-identity-provider",
+              "idProviderSvcPort": 4300
+            },
+            "mcmMonitor": {
+              "isHubCluster": false,
+              "serviceAccount": "ibm-monitoring-mcm-ctl"
+            },
+            "prometheusConfig": {
+              "logLevel": "info",
+              "nodeCPUThreshold": 85,
+              "nodeMemoryThreshold": 85,
+              "retention": "24h",
+              "serviceAccount": "ibm-monitoring-prometheusext-operand",
+              "servicePort": 9090
+            },
+            "prometheusOperator": {},
+            "storageClassName": ""
+          }
+        },
+        {
+          "apiVersion":"operator.ibm.com/v1alpha1",
+          "kind":"OperandRequest",
+          "metadata":{
+            "name":"monitoring-prometheus-ext-operator-request"
+          },
+          "spec":{
+            "requests":[
+              {
+                "operands":[
+                  {
+                    "name":"ibm-cert-manager-operator"
+                  },
+                  {
+                    "name": "ibm-iam-operator"
+                  },
+                  {
+                    "name": "ibm-management-ingress-operator"
+                  },
+                  {
+                    "name": "ibm-commonui-operator"
+                  }
+                ],
+                "registry":"common-service"
+              }
+            ]
+          }
+        }
+      ]
+    capabilities: Basic Install
+    categories: Monitoring
+    certified: "false"
+    createdAt: "2020-03-25 12:00:00"
+    description:
+      Deploys Prometheus and Alertmanager instances with RBAC enabled.
+      It will also enable Multicloud monitoring
+    repository: https://github.com/IBM/ibm-monitoring-prometheus-operator-ext
+    containerImage: quay.io/opencloudio/ibm-monitoring-prometheusext-operator
+    support: IBM
+  name: ibm-monitoring-prometheus-operator-ext.v1.11.0
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+      - description:
+          PrometheusExt will start Prometheus and Alertmanager instances
+          with RBAC enabled. It will also enable Multicloud monitoring
+        displayName: Prometheus Operator Extension
+        kind: PrometheusExt
+        name: prometheusexts.monitoring.operator.ibm.com
+        resources:
+          - kind: Deployment
+            version: v1
+          - kind: Service
+            version: v1
+          - kind: Prometheus
+            version: v1
+          - kind: Ingress
+            version: v1beta1
+          - kind: Certificate
+            version: v1alpha1
+          - kind: PrometheusExt
+            version: v1alpha1
+          - kind: Alertmanager
+            version: v1
+        specDescriptors:
+          - description: Host value of route cp-console
+            displayName: Cluster Address
+            path: clusterAddress
+          - description: Cluster domain name, cluster.local by default
+            displayName: Cluster Domain
+            path: clusterDomain
+          - description: Cluster name, mycluster by default
+            displayName: Cluster Name
+            path: clusterName
+          - description: Port value of route cp-console
+            displayName: Cluster Port
+            path: clusterPort
+          - description: Image of configmap reloader
+            displayName: Configmap Reload Image
+            path: configmapReloadImage
+          - description: Grafana service name trusted by prometheus
+            displayName: Grafana Svc Name
+            path: grafanaSvcName
+          - description: Grafana service port truested by prometheus
+            displayName: Grafana Svc Port
+            path: grafanaSvcPort
+          - description: Image of prometheus
+            displayName: Image
+            path: image
+          - description: Image pull policy
+            displayName: Image Policy
+            path: imagePolicy
+          - description: Extra image pull secrets
+            displayName: Image Pull Secrets
+            path: imagePullSecrets
+          - description: Image of prometheus config reloader
+            displayName: Prometheus Config Image
+            path: prometheusConfigImage
+          - description: repo:tag for router image
+            displayName: Router Image
+            path: routerImage
+          - description: Storage class name used by Prometheus and Alertmanager
+            displayName: Storage Class Name
+            path: storageClassName
+          - description: Inforamtion for prometheus operator deployment
+            displayName: Prometheus Operator
+            path: prometheusOperator
+          - description: Helm API service information
+            displayName: Helm Releases API
+            path: helmReleasesMonitor
+          - description: Configurations for IAM Provider
+            displayName: IAM Provider
+            path: iamProvider
+          - description: Configurations for tls certification
+            displayName: Certs
+            path: certs
+          - description: Configurations for mcm monitor controller
+            displayName: MCM Monitor Controller
+            path: mcmMonitor
+          - description: Configurations for prometheus
+            displayName: Prometheus Configuration
+            path: prometheusConfig
+          - description: Configurations for alertmanager
+            displayName: Alertmanager Configuration
+            path: alertManagerConfig
+        statusDescriptors:
+          - description: Status of the alert manager CR, created or not
+            displayName: Alertmanager
+            path: alertmanager
+          - description: Status of required configmaps, created or not
+            displayName: Configmaps
+            path: configmaps
+          - description: Status of the prometheus CR, created or not
+            displayName: Prometheus
+            path: prometheus
+          - description: Status of prometheus operator deployment
+            displayName: Prometheus Operator
+            path: prometheusOperator
+          - description: Status of required secrets, created or not
+            displayName: Secrets
+            path: secrets
+        version: v1alpha1
+  description: "**Important:** Do not install this operator directly. Only install this operator using the IBM Common Services Operator. For more information about installing this operator and other Common Services operators, see [Installer documentation](http://ibm.biz/cpcs_opinstall). **Additionally, you can exit this panel and navigate to the IBM Common Services tile in OperatorHub to learn more about the operator**.\n\n If you are using this operator as part of an IBM Cloud Pak, see the documentation for that IBM Cloud Pak to learn more about how to install and use the operator service. For more information about IBM Cloud Paks, see [IBM Cloud Paks that use Common Services](http://ibm.biz/cpcs_cloudpaks).\n\n You can use the ibm-monitoring-prometheusext-operator to install the prometheus to monitoring services of other IBM Cloud Platform Common Services, \r and monitor other services or Cloud Paks that you install. \n\nFor more information about the available IBM Cloud Platform Common Services, see the [IBM Knowledge Center](http://ibm.biz/cpcsdocs). \n## Supported platforms \n\n Red Hat OpenShift Container Platform 4.2 or newer installed on one of the following platforms: \n\n- Linux x86_64 \n- Linux on Power (ppc64le) \n- Linux on IBM Z and LinuxONE \n## Prerequisites\n\n Before you install this operator, you need to first install the operator dependencies and prerequisites: \n- For the list of operator dependencies, see the IBM Knowledge Center [Common Services dependencies documentation](http://ibm.biz/cpcs_opdependencies). \n- For the list of prerequisites for installing the operator, see the IBM Knowledge Center [Preparing to install services documentation](http://ibm.biz/cpcs_opinstprereq). \n## Documentation \n\n To install the operator with the IBM Common Services Operator follow the the installation and configuration instructions within the IBM Knowledge Center. \n- If you are using the operator as part of an IBM Cloud Pak, see the documentation for that IBM Cloud Pak, for a list of IBM Cloud Paks, see [IBM Cloud Paks that use Common Services](http://ibm.biz/cpcs_cloudpaks). \n- If you are using the operator with an IBM Containerized Software, see the IBM Cloud Platform Common Services Knowledge Center [Installer documentation](http://ibm.biz/cpcs_opinstall)."
+  displayName: IBM Monitoring Prometheus Extension
+  icon:
+    - base64data: PHN2ZyB3aWR0aD0iMjQ5MCIgaGVpZ2h0PSIyNTAwIiB2aWV3Qm94PSIwIDAgMjU2IDI1NyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiBwcmVzZXJ2ZUFzcGVjdFJhdGlvPSJ4TWlkWU1pZCI+PHBhdGggZD0iTTEyOC4wMDEuNjY3QzU3LjMxMS42NjcgMCA1Ny45NzEgMCAxMjguNjY0YzAgNzAuNjkgNTcuMzExIDEyNy45OTggMTI4LjAwMSAxMjcuOTk4UzI1NiAxOTkuMzU0IDI1NiAxMjguNjY0QzI1NiA1Ny45NyAxOTguNjg5LjY2NyAxMjguMDAxLjY2N3ptMCAyMzkuNTZjLTIwLjExMiAwLTM2LjQxOS0xMy40MzUtMzYuNDE5LTMwLjAwNGg3Mi44MzhjMCAxNi41NjYtMTYuMzA2IDMwLjAwNC0zNi40MTkgMzAuMDA0em02MC4xNTMtMzkuOTRINjcuODQyVjE3OC40N2gxMjAuMzE0djIxLjgxNmgtLjAwMnptLS40MzItMzMuMDQ1SDY4LjE4NWMtLjM5OC0uNDU4LS44MDQtLjkxLTEuMTg4LTEuMzc1LTEyLjMxNS0xNC45NTQtMTUuMjE2LTIyLjc2LTE4LjAzMi0zMC43MTYtLjA0OC0uMjYyIDE0LjkzMyAzLjA2IDI1LjU1NiA1LjQ1IDAgMCA1LjQ2NiAxLjI2NSAxMy40NTggMi43MjItNy42NzMtOC45OTQtMTIuMjMtMjAuNDI4LTEyLjIzLTMyLjExNiAwLTI1LjY1OCAxOS42OC00OC4wNzkgMTIuNTgtNjYuMjAxIDYuOTEuNTYyIDE0LjMgMTQuNTgzIDE0LjggMzYuNTA1IDcuMzQ2LTEwLjE1MiAxMC40Mi0yOC42OSAxMC40Mi00MC4wNTYgMC0xMS43NjkgNy43NTUtMjUuNDQgMTUuNTEyLTI1LjkwNy02LjkxNSAxMS4zOTYgMS43OSAyMS4xNjUgOS41MyA0NS40IDIuOTAyIDkuMTAzIDIuNTMyIDI0LjQyMyA0Ljc3MiAzNC4xMzguNzQ0LTIwLjE3OCA0LjIxMy00OS42MiAxNy4wMTQtNTkuNzg0LTUuNjQ3IDEyLjguODM2IDI4LjgxOCA1LjI3IDM2LjUxOCA3LjE1NCAxMi40MjQgMTEuNDkgMjEuODM2IDExLjQ5IDM5LjYzOCAwIDExLjkzNi00LjQwNyAyMy4xNzMtMTEuODQgMzEuOTU4IDguNDUyLTEuNTg2IDE0LjI4OS0zLjAxNiAxNC4yODktMy4wMTZsMjcuNDUtNS4zNTVjLjAwMi0uMDAyLTMuOTg3IDE2LjQwMS0xOS4zMTQgMzIuMTk3eiIgZmlsbD0iI0RBNEUzMSIvPjwvc3ZnPg==
+      mediatype: image/svg+xml
+  install:
+    spec:
+      Permissions:
+        - rules:
+            - apiGroups:
+                - ""
+              resources:
+                - pods
+                - services
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                - configmaps
+                - secrets
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - delete
+            - apiGroups:
+                - apps
+              resources:
+                - deployments
+                - statefulsets
+                - replicasets
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - delete
+            - apiGroups:
+                - monitoring.coreos.com
+              resources:
+                - prometheuses
+                - alertmanagers
+                - servicemonitors
+                - prometheusrules
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - delete
+            - apiGroups:
+                - certmanager.k8s.io
+              resources:
+                - certificates
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - delete
+            - apiGroups:
+                - monitoring.operator.ibm.com
+              resources:
+                - prometheusexts
+                - prometheusexts/finalizers
+                - prometheusexts/status
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - delete
+            - apiGroups:
+                - extensions
+              resources:
+                - ingresses
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - delete
+          serviceAccountName: ibm-monitoring-prometheus-operator-ext
+        - rules:
+            - apiGroups:
+                - ""
+              resources:
+                - services
+                - events
+                - configmaps
+                - secrets
+                - pods
+                - services/finalizers
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - delete
+            - apiGroups:
+                - apiextensions.k8s.io
+              resources:
+                - customresourcedefinitions
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - delete
+            - apiGroups:
+                - ""
+              resources:
+                - events
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - apps
+              resources:
+                - statefulsets
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - delete
+            - apiGroups:
+                - batch
+              resources:
+                - jobs
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - delete
+            - apiGroups:
+                - monitoring.coreos.com
+              resources:
+                - prometheuses
+                - alertmanagers
+                - servicemonitors
+                - prometheusrules
+                - podmonitors
+                - prometheuses/finalizers
+                - alertmanagers/finalizers
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - delete
+            - apiGroups:
+                - "monitoringcontroller.cloud.ibm.com"
+              resources:
+                - monitoringdashboards
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - delete
+            - apiGroups:
+                - "mcm.ibm.com"
+              resources:
+                - clusterstatuses
+              verbs:
+                - get
+                - list
+                - watch
+          serviceAccountName: ibm-monitoring-mcm-ctl
+        - rules:
+            - apiGroups:
+                - apiextensions.k8s.io
+              resources:
+                - customresourcedefinitions
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - delete
+            - apiGroups:
+                - monitoring.coreos.com
+              resources:
+                - alertmanagers
+                - prometheuses
+                - prometheuses/finalizers
+                - alertmanagers/finalizers
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - delete
+            - apiGroups:
+                - apps
+              resources:
+                - statefulsets
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - delete
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+                - secrets
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - delete
+            - apiGroups:
+                - ""
+              resources:
+                - pods
+              verbs:
+                - list
+                - delete
+            - apiGroups:
+                - ""
+              resources:
+                - services
+                - services/finalizers
+                - endpoints
+              verbs:
+                - get
+                - create
+                - update
+                - delete
+          serviceAccountName: prometheus-operator
+      clusterPermissions:
+        - rules:
+            - apiGroups:
+                - monitoring.coreos.com
+              resources:
+                - servicemonitors
+                - podmonitors
+                - prometheusrules
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - delete
+            - apiGroups:
+                - ""
+              resources:
+                - namespaces
+              verbs:
+                - get
+          serviceAccountName: prometheus-operator
+        - rules:
+            - apiGroups:
+                - ""
+              resources:
+                - services
+                - nodes
+                - nodes/proxy
+                - endpoints
+                - pods
+              verbs:
+                - get
+                - list
+                - watch
+            - nonResourceURLs: ["/metrics"]
+              verbs:
+                - get
+          serviceAccountName: ibm-monitoring-prometheusext-operand
+        - rules:
+            - apiGroups:
+                - storage.k8s.io
+              resources:
+                - storageclasses
+              verbs:
+                - list
+                - watch
+            - apiGroups:
+                - security.openshift.io
+              resources:
+                - securitycontextconstraints
+              verbs:
+                - create
+                - update
+                - get
+          serviceAccountName: ibm-monitoring-prometheus-operator-ext
+      deployments:
+        - name: ibm-monitoring-prometheus-operator-ext
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                name: ibm-monitoring-prometheus-operator-ext
+            strategy: {}
+            template:
+              metadata:
+                annotations:
+                  productID: 068a62892a1e4db39641342e592daa25
+                  productMetric: FREE
+                  productName: IBM Cloud Platform Common Services
+                labels:
+                  name: ibm-monitoring-prometheus-operator-ext
+              spec:
+                hostIPC: false
+                hostNetwork: false
+                hostPID: false
+                affinity:
+                  nodeAffinity:
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      nodeSelectorTerms:
+                        - matchExpressions:
+                            - key: kubernetes.io/arch
+                              operator: In
+                              values:
+                                - amd64
+                                - ppc64le
+                                - s390x
+                containers:
+                  - command:
+                      - ibm-monitoring-prometheusext-operator
+                    env:
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.annotations['olm.targetNamespaces']
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: OPERATOR_NAME
+                        value: ibm-monitoring-prometheusext-operator
+                      - name: AM_IMAGE
+                        value: quay.io/opencloudio/alertmanager@sha256:3b7d78681b1163c655a7fee480af80b926ebd30a702dcbc8845b88a7cd00a9c7
+                      - name: PROME_IMAGE
+                        value: quay.io/opencloudio/prometheus@sha256:64b44a34a7ffb46d6d7a3a3a3e9e5b2648688bab87db40acf1b3fe28efc44df9
+                      - name: CM_RELOAD_IMAGE
+                        value: quay.io/opencloudio/configmap-reload@sha256:f475ee1b178a0020414c670d98d9df0810718b7a45ff95a4057ebf4905a14f9b
+                      - name: PROM_OP_IMAGE
+                        value: quay.io/opencloudio/prometheus-operator@sha256:97c5647038f5ebc5c5923ef20e61cdf51a3321d7360000ad3b78fb6a38b2daf7
+                      - name: PROM_CONF_IMAGE
+                        value: quay.io/opencloudio/prometheus-config-reloader@sha256:6d76da1fe18ac9c343dbd104d2763e2918c9ed89b7dac659907286eda9fe0e94
+                      - name: ROUTER_IMAGE
+                        value: quay.io/opencloudio/icp-management-ingress@sha256:6641653b351901eb9352e06479d75a4babaf746bcd63381a09a58d9192b0953c
+                      - name: MCM_HELPER_IMAGE
+                        value: quay.io/opencloudio/icp-initcontainer@sha256:87b30476a024b7a3870cd6b68c0f859cd29b908e9c99f07375f3dfb29d00b963
+                      - name: MCM_IMAGE
+                        value: quay.io/opencloudio/prometheus-controller@sha256:6a4656104448b38c4ef8802133f2960090fbaea3a80baef4939e96b6f4b3c646
+                    image: quay.io/opencloudio/ibm-monitoring-prometheusext-operator
+                    imagePullPolicy: Always
+                    name: ibm-monitoring-prometheus-operator-ext
+                    resources:
+                      limits:
+                        cpu: 50m
+                        memory: 512Mi
+                      requests:
+                        cpu: 20m
+                        memory: 64Mi
+                serviceAccountName: ibm-monitoring-prometheus-operator-ext
+    strategy: deployment
+  installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: false
+      type: AllNamespaces
+  maturity: stable
+  keywords:
+    - monitoring
+    - prometheus
+  maintainers:
+    - email: supports@ibm.com
+      name: IBM Support
+  links:
+    - name: Promethues Extension Operator
+      url: https://github.com/IBM/ibm-monitoring-prometheus-operator-ext
+    - name: Prometheus Operator
+      url: https://github.com/coreos/prometheus-operator
+    - name: Prometheus
+      url: https://www.prometheus.io/
+  provider:
+    name: IBM
+  replaces: ibm-monitoring-prometheus-operator-ext.v1.10.1
+  version: 1.11.0

--- a/deploy/olm-catalog/ibm-monitoring-prometheus-operator-ext/1.11.0/monitoring.operator.ibm.com_prometheusexts_crd.yaml
+++ b/deploy/olm-catalog/ibm-monitoring-prometheus-operator-ext/1.11.0/monitoring.operator.ibm.com_prometheusexts_crd.yaml
@@ -1,0 +1,398 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/name: ibm-monitoring
+    app.kubernetes.io/instance: common-monitoring
+    app.kubernetes.io/managed-by: ibm-monitoring-prometheusext-operator
+  name: prometheusexts.monitoring.operator.ibm.com
+spec:
+  group: monitoring.operator.ibm.com
+  names:
+    kind: PrometheusExt
+    listKind: PrometheusExtList
+    plural: prometheusexts
+    singular: prometheusext
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: PrometheusExt will start Prometheus and Alertmanager instances
+        with RBAC enabled. It will also enable Multicloud monitoring
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: PrometheusExtSpec defines the desired state of PrometheusExt
+          properties:
+            alertManagerConfig:
+              description: Configurations for alertmanager
+              properties:
+                imageRepo:
+                  type: string
+                imageTag:
+                  type: string
+                logLevel:
+                  type: string
+                pvSize:
+                  type: string
+                resource:
+                  description: ResourceRequirements describes the compute resource
+                    requirements.
+                  properties:
+                    limits:
+                      additionalProperties:
+                        type: string
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        type: string
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                  type: object
+                serviceAccount:
+                  type: string
+                servicePort:
+                  format: int32
+                  type: integer
+              required:
+              - servicePort
+              type: object
+            certs:
+              description: Configurations for tls certification
+              properties:
+                autoClean:
+                  description: If it is false, user can create secret manually before
+                    creating CR and operator will not recreate it if secret exists
+                    already If it is true, operator will recreate secret if it is
+                    not created by certificate (cert-manager)
+                  type: boolean
+                issuer:
+                  description: The issure name. It is used to generated tls certificates.
+                    All tls certificates of monitoring operators need to use same
+                    Issuer
+                  type: string
+                monitoringClientSecret:
+                  description: Define monitoring stack client(prometheus, exporters)'s
+                    tls cert secret. It is created by cert manager
+                  type: string
+                monitoringSecret:
+                  description: Prometheus and AlertManager' tls cert. Define the secret
+                    name. It is created by cert manager
+                  type: string
+              required:
+              - issuer
+              - monitoringClientSecret
+              - monitoringSecret
+              type: object
+            clusterAddress:
+              description: Host value of route cp-console
+              type: string
+            clusterDomain:
+              description: Cluster domain name, cluster.local by default
+              type: string
+            clusterName:
+              description: Cluster name, mycluster by default
+              type: string
+            clusterPort:
+              description: Port value of route cp-console
+              format: int32
+              type: integer
+            grafanaSvcName:
+              description: Grafana service name trusted by prometheus
+              type: string
+            grafanaSvcPort:
+              description: Grafana service port truested by prometheus
+              format: int32
+              type: integer
+            helmReleasesMonitor:
+              description: Helm API service information
+              properties:
+                namespace:
+                  type: string
+                port:
+                  format: int32
+                  type: integer
+              type: object
+            iamProvider:
+              description: Configurations for IAM Provider
+              properties:
+                idManagementSvc:
+                  type: string
+                idManagementSvcPort:
+                  format: int32
+                  type: integer
+                idProviderSvc:
+                  type: string
+                idProviderSvcPort:
+                  format: int32
+                  type: integer
+                namespace:
+                  type: string
+              required:
+              - idManagementSvc
+              - idManagementSvcPort
+              - idProviderSvc
+              - idProviderSvcPort
+              type: object
+            imagePolicy:
+              description: Image pull policy
+              type: string
+            imagePullSecrets:
+              description: Extra image pull secrets
+              items:
+                type: string
+              type: array
+            mcmMonitor:
+              description: Configurations for mcm monitor controller
+              properties:
+                helpeImage:
+                  description: MCM helper image for some initiallizing work
+                  type: string
+                image:
+                  description: Image for mcm monitoring controller
+                  type: string
+                isHubCluster:
+                  description: If it is running on MCM Hub cluster or not
+                  type: boolean
+                resource:
+                  description: ResourceRequirements describes the compute resource
+                    requirements.
+                  properties:
+                    limits:
+                      additionalProperties:
+                        type: string
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        type: string
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                  type: object
+                serviceAccount:
+                  type: string
+              type: object
+            nodeSelector:
+              additionalProperties:
+                type: string
+              type: object
+            prometheusConfig:
+              description: Configurations for prometheus
+              properties:
+                evaluationInterval:
+                  type: string
+                imageRepo:
+                  type: string
+                imageTag:
+                  type: string
+                logLevel:
+                  type: string
+                nodeCPUThreshold:
+                  type: integer
+                nodeMemoryThreshold:
+                  type: integer
+                pvSize:
+                  type: string
+                resource:
+                  description: ResourceRequirements describes the compute resource
+                    requirements.
+                  properties:
+                    limits:
+                      additionalProperties:
+                        type: string
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        type: string
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                  type: object
+                retention:
+                  type: string
+                routerResource:
+                  description: ResourceRequirements describes the compute resource
+                    requirements.
+                  properties:
+                    limits:
+                      additionalProperties:
+                        type: string
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        type: string
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                  type: object
+                scrapeInterval:
+                  type: string
+                serviceAccount:
+                  type: string
+                servicePort:
+                  format: int32
+                  type: integer
+              required:
+              - nodeCPUThreshold
+              - nodeMemoryThreshold
+              - servicePort
+              type: object
+            prometheusOperator:
+              description: PrometheusOperator defines inforamtion for prometheus operator
+                deployment
+              properties:
+                configmapReloadImage:
+                  description: Image of configmap reloader
+                  type: string
+                image:
+                  description: Image of prometheus
+                  type: string
+                prometheusConfigImage:
+                  description: Image of prometheus config reloader
+                  type: string
+              type: object
+            routerImage:
+              description: repo:tag for router image
+              type: string
+            storageClassName:
+              description: Storage class name used by Prometheus and Alertmanager
+              type: string
+          required:
+          - alertManagerConfig
+          - certs
+          - grafanaSvcName
+          - grafanaSvcPort
+          - iamProvider
+          - prometheusConfig
+          - storageClassName
+          type: object
+        status:
+          description: PrometheusExtStatus defines the observed state of PrometheusExt
+          properties:
+            alertmanager:
+              description: Status of the alert manager CR, created or not
+              type: string
+            configmaps:
+              description: Status of required configmaps, created or not
+              type: string
+            exporter:
+              description: Status of the exporter CR, created or not
+              type: string
+            prometheus:
+              description: Status of the prometheus CR, created or not
+              type: string
+            prometheusOperator:
+              description: Status of prometheus operator deployment
+              properties:
+                availableReplicas:
+                  description: Total number of available pods (ready for at least
+                    minReadySeconds) targeted by this deployment.
+                  format: int32
+                  type: integer
+                collisionCount:
+                  description: Count of hash collisions for the Deployment. The Deployment
+                    controller uses this field as a collision avoidance mechanism
+                    when it needs to create the name for the newest ReplicaSet.
+                  format: int32
+                  type: integer
+                conditions:
+                  description: Represents the latest available observations of a deployment's
+                    current state.
+                  items:
+                    description: DeploymentCondition describes the state of a deployment
+                      at a certain point.
+                    properties:
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one
+                          status to another.
+                        format: date-time
+                        type: string
+                      lastUpdateTime:
+                        description: The last time this condition was updated.
+                        format: date-time
+                        type: string
+                      message:
+                        description: A human readable message indicating details about
+                          the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False,
+                          Unknown.
+                        type: string
+                      type:
+                        description: Type of deployment condition.
+                        type: string
+                    required:
+                    - status
+                    - type
+                    type: object
+                  type: array
+                observedGeneration:
+                  description: The generation observed by the deployment controller.
+                  format: int64
+                  type: integer
+                readyReplicas:
+                  description: Total number of ready pods targeted by this deployment.
+                  format: int32
+                  type: integer
+                replicas:
+                  description: Total number of non-terminated pods targeted by this
+                    deployment (their labels match the selector).
+                  format: int32
+                  type: integer
+                unavailableReplicas:
+                  description: Total number of unavailable pods targeted by this deployment.
+                    This is the total number of pods that are still required for the
+                    deployment to have 100% available capacity. They may either be
+                    pods that are running but not yet available or pods that still
+                    have not been created.
+                  format: int32
+                  type: integer
+                updatedReplicas:
+                  description: Total number of non-terminated pods targeted by this
+                    deployment that have the desired template spec.
+                  format: int32
+                  type: integer
+              type: object
+            secrets:
+              description: Status of required secrets, created or not
+              type: string
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/deploy/olm-catalog/ibm-monitoring-prometheus-operator-ext/ibm-monitoring-prometheus-operator-ext.package.yaml
+++ b/deploy/olm-catalog/ibm-monitoring-prometheus-operator-ext/ibm-monitoring-prometheus-operator-ext.package.yaml
@@ -5,7 +5,7 @@ channels:
     name: beta
   - currentCSV: ibm-monitoring-prometheus-operator-ext.v1.9.5
     name: dev
-  - currentCSV: ibm-monitoring-prometheus-operator-ext.v1.10.1
+  - currentCSV: ibm-monitoring-prometheus-operator-ext.v1.11.0
     name: v3
 defaultChannel: stable-v1
 packageName: ibm-monitoring-prometheusext-operator-app

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -42,7 +42,12 @@ rules:
   - podmonitors
   - prometheusrules
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
 - apiGroups:
   - ''
   resources:
@@ -98,7 +103,12 @@ rules:
   - configmaps
   - secrets
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
 - apiGroups:
   - apps
   resources:
@@ -106,7 +116,12 @@ rules:
   - statefulsets
   - replicasets
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
 - apiGroups:
   - monitoring.coreos.com
   resources:
@@ -115,13 +130,23 @@ rules:
   - servicemonitors
   - prometheusrules
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
 - apiGroups:
   - certmanager.k8s.io
   resources:
   - certificates
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
 - apiGroups:
   - monitoring.operator.ibm.com
   resources:
@@ -129,19 +154,23 @@ rules:
   - prometheusexts/finalizers
   - prometheusexts/status
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
 - apiGroups:
   - extensions
   resources:
   - ingresses
   verbs:
-  - '*'
-- apiGroups:
-  - certmanager.k8s.io
-  resources:
-  - issuers
-  verbs:
-  - use
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -163,13 +192,23 @@ rules:
   - pods
   - services/finalizers
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
 - apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
 - apiGroups:
   - ""
   resources:
@@ -184,13 +223,22 @@ rules:
   resources:
   - statefulsets
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
 - apiGroups:
   - batch
   resources:
   - jobs
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
 - apiGroups:
   - monitoring.coreos.com
   resources:
@@ -202,13 +250,23 @@ rules:
   - prometheuses/finalizers
   - alertmanagers/finalizers
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
 - apiGroups:
   - "monitoringcontroller.cloud.ibm.com"
   resources:
   - monitoringdashboards
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
 - apiGroups:
   - "mcm.ibm.com"
   resources:
@@ -233,7 +291,12 @@ rules:
   resources:
   - customresourcedefinitions
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
 - apiGroups:
   - monitoring.coreos.com
   resources:
@@ -242,20 +305,35 @@ rules:
   - prometheuses/finalizers
   - alertmanagers/finalizers
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
 - apiGroups:
   - apps
   resources:
   - statefulsets
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
 - apiGroups:
   - ''
   resources:
   - configmaps
   - secrets
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
 - apiGroups:
   - ''
   resources:

--- a/version/version.go
+++ b/version/version.go
@@ -17,5 +17,5 @@
 package version
 
 var (
-	Version = "1.10.1"
+	Version = "1.11.0"
 )


### PR DESCRIPTION
In order to reduce the namespace-scope operator permissions, we need the operator and operands have enumerated the required verbs. Hence part of fix , we are removing the wildchar (*) verb and specified the required verbs in the CSV as well as in the role file.

As the existing csv (`1.10.1`) is in release protection , hence the changes are done with bumping up the csv version (`1.11.0`).

Issue https://github.ibm.com/IBMPrivateCloud/roadmap/issues/45003